### PR TITLE
ci: run release gates on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: ci
+
+# 打开 PR / 合入 main 时跑与 release 相同的验收 gate，外加前端单测。
+# 真机 e2e（#[ignore]）仍按 CONTRIBUTING 本地单独跑，不在此流水线。
+# rustfmt 暂未纳入：release 尚未 gate，单独引入会让本 PR 卡在历史格式上。
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  gates:
+    name: test-and-lint
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.18.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      # --- 与 release.yml 对齐的四道 gate ---
+
+      - name: Gate 1 — cargo test
+        run: cargo test --workspace
+
+      - name: Gate 2 — cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Gate 3 — tsc
+        working-directory: apps/desktop
+        run: npx tsc --noEmit
+
+      - name: Gate 4 — instance_system 集成测试
+        run: cargo test -p launcher-core --test instance_system
+
+      # --- 前端单测（release 尚未跑，PR 必须绿） ---
+
+      - name: Gate 5 — vitest
+        working-directory: apps/desktop
+        run: npx vitest run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 > 欢迎！**AI Harness Launcher** 是一个用 Tauri 2 + Rust 构建的「PCL for AI Harnesses」Windows 桌面启动器：管理 DSH 运行时、多实例、Provider、插件，然后一键 Launch。
 >
-> 动手前请先读 [`README.md`](./README.md)（怎么跑）和 [`plan.md`](./plan.md)（路线与每阶段的验收 Gate）。这份文档约 5 分钟，能帮你少走 90% 的弯路。
+> 动手前请先读 [`README.md`](./README.md)（怎么跑）和本文件（分支、提交、测试与评审约定）。这份文档约 5 分钟，能帮你少走 90% 的弯路。
 
 ## 目录
 
@@ -35,7 +35,7 @@ scripts/                      开发辅助脚本（如 gen-icon.mjs）
 
 ### 语言边界（红线）
 
-项目刻意把「边界」定死（见 plan.md 第「三」节）：
+项目刻意把「边界」定死：
 
 - **TypeScript 只管 UI**：页面、表单、状态、展示。
 - **Rust 只管系统**：进程、文件系统、网络、密钥、SQLite、运行时管理。
@@ -126,7 +126,7 @@ ci: 新增 release 流水线四道 gate
    - **为什么**：关联 issue、要解决的问题
    - **改了什么**：涉及的文件/模块、设计取舍
    - **怎么测**：跑过的命令与结果；真机行为（如 Launch→窗口→Stop）附输出/截图
-5. 打 `draft` 直到能通过全部 CI gate（P2 落地后会自动跑）。
+5. 打 `draft` 直到能通过全部 CI gate（`.github/workflows/ci.yml` 会在 PR 上自动跑）。
 6. 至少 1 人 review 通过 + CI 全绿才可合并。
 
 ## 代码规范
@@ -167,4 +167,4 @@ ci: 新增 release 流水线四道 gate
 
 - 用模板：**现象 / 期望 / 环境**；bug 附日志（`%LOCALAPPDATA%/AIHarnessLauncher/logs/launcher.log`）与复现步骤。
 - 一个 issue 一件事；用标签 `bug` `enhancement` `ci` `docs` `p2`–`p6`。
-- 完成后在 [`TODO.md`](./TODO.md) 勾掉对应项，并 `Closes #NNN`。
+- 完成后在对应 PR 里写清 `Closes #NNN`，合并时自动关 issue。

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ dsh-launcher/
 │   ├── launcher-core/          框架无关核心：paths/settings/instance/provider/process/runtime/market/mcp
 │   └── dsh-adapter/            DSH 专用适配器（RuntimeAdapter 实现）：runtimes/theme/mcp probe/import/resolver
 ├── tui/                        dsh-tauri 参考镜像（内嵌窗口机制）
-├── scripts/                    开发辅助（图标生成、目录生成、解析器）
-└── docs/                       文档
+└── scripts/                    开发辅助（图标生成、目录生成、解析器）
 ```
 
 **语言边界（有意为之）：** TypeScript 负责 UI；Rust 负责系统（进程、文件系统、网络、密钥、SQLite）。所有系统动作经类型化 Tauri IPC —— 见 [`CONTRIBUTING.md`](CONTRIBUTING.md)。


### PR DESCRIPTION
## Why

CONTRIBUTING requires a green CI before merge, but the only workflow in `.github/workflows/` is `release.yml`, which only runs on `v*` tags. Contributors cannot tell whether `cargo test`, clippy, `tsc`, or the `instance_system` suite still pass on a branch, and the three frontend vitest files never run in automation.

Two docs also point at files that are not in the repo: `CONTRIBUTING.md` links `plan.md` / `TODO.md`, and `README.md` lists a `docs/` directory that does not exist.

## What

- Add `.github/workflows/ci.yml` on `pull_request` and `push` to `main`.
- Same `windows-latest` job shape as `release.yml` (pnpm 11.18.0, Node 22, stable Rust + clippy, `Swatinem/rust-cache`).
- Run the four release gates plus `npx vitest run` in `apps/desktop`.
- Leave `rustfmt` out for now — release does not gate on it, and enabling it here would fail on the current tree.
- Keep ignored real-machine e2e walks local, per the existing convention.
- Fix `CONTRIBUTING.md` dead links (`plan.md`, `TODO.md`, "P2" placeholder → points at `ci.yml`).
- Drop the non-existent `docs/` line from the README tree.

## How tested

- Diff is workflow + docs only; no application code.
- `ci.yml` copies the already-shipping release gate commands.
- Vitest already has `mcpConfig.test.ts`, `theme.test.ts`, `appStore.test.ts` under `apps/desktop/src`.

Happy to adjust the job matrix or add `cargo fmt --check` in a follow-up once the tree is formatted.